### PR TITLE
Fixing a bug in Firefox.

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
 		   </div>
       </div>
       
-		<div class="row" style="height:calc( 100% - 27px ); background-color: aquamarine;">
+		<div class="row" style="height:calc( 100vh - 27px ); background-color: aquamarine;">
 			<div class="col-md-7" style="padding:0px;height:110%;"> 
 			      
             <div id="editor">function Main()


### PR DESCRIPTION
Only the top bar shows up in Firefox, because of some weird interaction of the `calc()` function with the `100%`. This change replaces it with the `vh` unit, which measures percentages of the window height.